### PR TITLE
Enable selection of Heroku's webapp-runner instead of Vincit's fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,40 @@
-Heroku buildpack: Java
-=========================
+# Heroku buildpack: Java
 
 This is a [Heroku buildpack](http://devcenter.heroku.com/articles/buildpack) for Java apps.
 It uses Maven 3.2.5 to build your application and OpenJDK 8u20 to run it (by default).
 
 This fork also installs node.js and npm and uses webapp-runner to run the .war without requiring a bundled tomcat in Dokku.
 
+Two webapp-runner versions are supported:
+
+- [Vincit](https://github.com/Vincit/webapp-runner.git)'s fork that uses Tomcat 7.0.
+- [heroku](https://github.com/heroku/webapp-runner.git)'s official version that currently uses Tomcat 8.5. **Note!** Heroku's version does not support `--force-https` option.
+
+By default, Vincit's version of webapp-runner is being used, and the Heroku's version can be selected by defining environment variable `WEBAPP_RUNNER_VERSION=heroku`.
+
+E.g.
+
+```
+$ ssh dokku@dokku.dmz.vincit.fi config:set <app name> WEBAPP_RUNNER_VERSION=heroku
+
+# Set explicitly Vincit's version of webapp-runner to be used
+$ ssh dokku@dokku.dmz.vincit.fi config:set <app name> WEBAPP_RUNNER_VERSION=Vincit
+```
+
 ## How it works
 
-The buildpack will detect your app as Java if it has a `pom.xml` file in its root directory.  It will use Maven to execute the build defined by your `pom.xml` and download your dependencies. The `.m2` folder (local maven repository) will be cached between builds for faster dependency resolution. However neither the mvn executable or the .m2 folder will be available in your slug at runtime.
+The buildpack will detect your app as Java if it has a `pom.xml` file in its root directory. It will use Maven to execute the build defined by your `pom.xml` and download your dependencies. The `.m2` folder (local maven repository) will be cached between builds for faster dependency resolution. However neither the mvn executable or the .m2 folder will be available in your slug at runtime.
 
 ## Documentation
 
 For more information about using Java and buildpacks on Heroku, see these Dev Center articles:
 
-*  [Heroku Java Support](https://devcenter.heroku.com/articles/java-support)
-*  [Introduction to Heroku for Java Developers](https://devcenter.heroku.com/articles/intro-for-java-developers)
-*  [Deploying Tomcat-based Java Web Applications with Webapp Runner](https://devcenter.heroku.com/articles/java-webapp-runner)
-*  [Deploy a Java Web Application that launches with Jetty Runner](https://devcenter.heroku.com/articles/deploy-a-java-web-application-that-launches-with-jetty-runner)
-*  [Using a Custom Maven Settings File](https://devcenter.heroku.com/articles/using-a-custom-maven-settings-xml)
-*  [Using Grunt with Java and Maven to Automate JavaScript Tasks](https://devcenter.heroku.com/articles/using-grunt-with-java-and-maven-to-automate-javascript-tasks)
+- [Heroku Java Support](https://devcenter.heroku.com/articles/java-support)
+- [Introduction to Heroku for Java Developers](https://devcenter.heroku.com/articles/intro-for-java-developers)
+- [Deploying Tomcat-based Java Web Applications with Webapp Runner](https://devcenter.heroku.com/articles/java-webapp-runner)
+- [Deploy a Java Web Application that launches with Jetty Runner](https://devcenter.heroku.com/articles/deploy-a-java-web-application-that-launches-with-jetty-runner)
+- [Using a Custom Maven Settings File](https://devcenter.heroku.com/articles/using-a-custom-maven-settings-xml)
+- [Using Grunt with Java and Maven to Automate JavaScript Tasks](https://devcenter.heroku.com/articles/using-grunt-with-java-and-maven-to-automate-javascript-tasks)
 
 ## Configuration
 
@@ -61,8 +76,8 @@ versions of Maven by submitting a pull request against `vendor/maven/sources.txt
 
 There are three config variables that can be used to customize the Maven execution:
 
-+ `MAVEN_CUSTOM_GOALS`: set to `clean install` by default
-+ `MAVEN_CUSTOM_OPTS`: set to `-DskipTests=true` by default
+- `MAVEN_CUSTOM_GOALS`: set to `clean install` by default
+- `MAVEN_CUSTOM_OPTS`: set to `-DskipTests=true` by default
 
 These variables can be set like this:
 
@@ -74,7 +89,6 @@ $ heroku config:set MAVEN_CUSTOM_OPTS="--update-snapshots -DskipTests=true"
 Other options are available for [defining custom a `settings.xml` file](https://devcenter.heroku.com/articles/using-a-custom-maven-settings-xml).
 
 ## Hacking
-
 
 To make changes to this buildpack, fork it on Github. Push up changes to your fork, then create a new Heroku app to test it, or configure an existing app to use your buildpack:
 
@@ -107,7 +121,6 @@ and then:
 
 and you'll see the `.m2` and `.maven` directories are now present in your slug.
 
-License
--------
+## License
 
 Licensed under the MIT License. See LICENSE file.

--- a/bin/compile
+++ b/bin/compile
@@ -13,7 +13,7 @@ BIN_DIR=$(cd $(dirname $0); pwd) # absolute path
 BUILD_DIR=$1
 CACHE_DIR=$2
 ENV_DIR=$3
-GLOBAL_CACHE_DIR=/global_cache
+GLOBAL_CACHE_DIR=/global_cache/test_new_java_nodejs
 
 # set up used webapp
 WEBAPP_RUNNER_VERSION=${WEBAPP_RUNNER_VERSION:-Vincit}

--- a/bin/compile
+++ b/bin/compile
@@ -276,10 +276,10 @@ done
 
 if [ ! -d $GLOBAL_CACHE_DIR ]; then
   echo "-----> Caching npm cache directory for future builds"
-  mkdir -p $CACHE_DIR/.npm && rsync -a --delete $BUILD_DIR/.npm/ $CACHE_DIR/.npm/
+  mkdir -p $CACHE_DIR/.npm && [ -d "$BUILD_DIR/.npm/" ] && rsync -a --delete $BUILD_DIR/.npm/ $CACHE_DIR/.npm/
 
   echo "-----> Caching bower cache directory for future builds"
-  mkdir -p $CACHE_DIR/.cache/bower && rsync -a --delete $HOME/.cache/bower/ $CACHE_DIR/.cache/bower/
+  mkdir -p $CACHE_DIR/.cache/bower && [ -d "$HOME/.cache/bower/" ] && rsync -a --delete $HOME/.cache/bower/ $CACHE_DIR/.cache/bower/
 fi
 
 echo "-----> Cleaning up cache directories"

--- a/bin/compile
+++ b/bin/compile
@@ -234,7 +234,7 @@ if [ -d $GLOBAL_CACHE_DIR/webapp-runner ]; then
     cd $BUILD_DIR
     cp -r $GLOBAL_CACHE_DIR/webapp-runner .
 else
-    git clone https://github.com/Vincit/webapp-runner.git 2>&1 | sed -u 's/^/        /'
+    git clone https://github.com/heroku/webapp-runner.git 2>&1 | sed -u 's/^/        /'
 
     if [ -d $GLOBAL_CACHE_DIR ]; then
         cp -r webapp-runner $GLOBAL_CACHE_DIR

--- a/bin/compile
+++ b/bin/compile
@@ -13,7 +13,7 @@ BIN_DIR=$(cd $(dirname $0); pwd) # absolute path
 BUILD_DIR=$1
 CACHE_DIR=$2
 ENV_DIR=$3
-GLOBAL_CACHE_DIR=/global_cache/test_new_java_nodejs
+GLOBAL_CACHE_DIR=/global_cache
 
 # set up used webapp
 WEBAPP_RUNNER_VERSION=${WEBAPP_RUNNER_VERSION:-Vincit}
@@ -23,7 +23,7 @@ case $WEBAPP_RUNNER_VERSION in
     echo "-----> Use Vincit's webapp-runner"
     WEBAPP_TARGET_JAR="target/webapp-runner.jar"
     WEBAPP_GIT_URL="https://github.com/Vincit/webapp-runner.git"
-    WEBAPP_CACHE_DIR="webapp-runner"
+    WEBAPP_CACHE_DIR="webapp-runner-vincit"
     ;;
   heroku)
     echo "-----> Use heroku's webapp-runner"
@@ -36,7 +36,7 @@ case $WEBAPP_RUNNER_VERSION in
     echo "-----> Using Vincit's version instead"
     WEBAPP_TARGET_JAR="target/webapp-runner.jar"
     WEBAPP_GIT_URL="https://github.com/Vincit/webapp-runner.git"
-    WEBAPP_CACHE_DIR="webapp-runner"
+    WEBAPP_CACHE_DIR="webapp-runner-vincit"
     ;;
 esac
 

--- a/bin/compile
+++ b/bin/compile
@@ -15,6 +15,28 @@ CACHE_DIR=$2
 ENV_DIR=$3
 GLOBAL_CACHE_DIR=/global_cache
 
+# set up used webapp
+WEBAPP_RUNNER_VERSION=${WEBAPP_RUNNER_VERSION:-Vincit}
+
+case $WEBAPP_RUNNER_VERSION in
+  Vincit)
+    echo "-----> Use Vincit's webapp_runner"
+    WEBAPP_TARGET_JAR="target/webapp-runner.jar"
+    WEBAPP_GIT_URL="https://github.com/Vincit/webapp-runner.git"
+    ;;
+  heroku)
+    echo "-----> Use heroku's webapp_runner"
+    WEBAPP_TARGET_JAR="assembly/target/webapp-runner.jar"
+    WEBAPP_GIT_URL="https://github.com/heroku/webapp-runner.git"
+    ;;
+  *)
+    echo "-----> Unknown webapp_runner version: ${WEBAPP_RUNNER_VERSION}"
+    echo "-----> Using Vincit's version instead"
+    WEBAPP_TARGET_JAR="target/webapp-runner.jar"
+    WEBAPP_GIT_URL="https://github.com/Vincit/webapp-runner.git"
+    ;;
+esac
+
 LOGGER_FLAGS=""
 
 export_env_dir $ENV_DIR
@@ -234,7 +256,7 @@ if [ -d $GLOBAL_CACHE_DIR/webapp-runner ]; then
     cd $BUILD_DIR
     cp -r $GLOBAL_CACHE_DIR/webapp-runner .
 else
-    git clone https://github.com/heroku/webapp-runner.git 2>&1 | sed -u 's/^/        /'
+    git clone "${WEBAPP_GIT_URL}" 2>&1 | sed -u 's/^/        /'
 
     if [ -d $GLOBAL_CACHE_DIR ]; then
         cp -r webapp-runner $GLOBAL_CACHE_DIR
@@ -257,7 +279,7 @@ status "executing $BUILDCMD"
 $BUILDCMD 2>&1 | sed -u 's/^/       /'
 
 mkdir -p ../target/dependency
-cp assembly/target/webapp-runner.jar ../target/dependency/webapp-runner.jar
+cp "${WEBAPP_TARGET_JAR}" ../target/dependency/webapp-runner.jar
 cd ..
 rm -rf webapp-runner
 

--- a/bin/compile
+++ b/bin/compile
@@ -20,20 +20,23 @@ WEBAPP_RUNNER_VERSION=${WEBAPP_RUNNER_VERSION:-Vincit}
 
 case $WEBAPP_RUNNER_VERSION in
   Vincit)
-    echo "-----> Use Vincit's webapp_runner"
+    echo "-----> Use Vincit's webapp-runner"
     WEBAPP_TARGET_JAR="target/webapp-runner.jar"
     WEBAPP_GIT_URL="https://github.com/Vincit/webapp-runner.git"
+    WEBAPP_CACHE_DIR="webapp-runner"
     ;;
   heroku)
-    echo "-----> Use heroku's webapp_runner"
+    echo "-----> Use heroku's webapp-runner"
     WEBAPP_TARGET_JAR="assembly/target/webapp-runner.jar"
     WEBAPP_GIT_URL="https://github.com/heroku/webapp-runner.git"
+    WEBAPP_CACHE_DIR="webapp-runner-heroku"
     ;;
   *)
-    echo "-----> Unknown webapp_runner version: ${WEBAPP_RUNNER_VERSION}"
+    echo "-----> Unknown webapp-runner version: ${WEBAPP_RUNNER_VERSION}"
     echo "-----> Using Vincit's version instead"
     WEBAPP_TARGET_JAR="target/webapp-runner.jar"
     WEBAPP_GIT_URL="https://github.com/Vincit/webapp-runner.git"
+    WEBAPP_CACHE_DIR="webapp-runner"
     ;;
 esac
 
@@ -250,23 +253,23 @@ if [ "${PIPESTATUS[*]}" != "0 0" ]; then
 fi
 
 # download webapp-runner
-if [ -d $GLOBAL_CACHE_DIR/webapp-runner ]; then
-    cd $GLOBAL_CACHE_DIR/webapp-runner
+if [ -d $GLOBAL_CACHE_DIR/$WEBAPP_CACHE_DIR ]; then
+    cd $GLOBAL_CACHE_DIR/$WEBAPP_CACHE_DIR
     git pull --ff-only 2>&1 >/dev/null
     cd $BUILD_DIR
-    cp -r $GLOBAL_CACHE_DIR/webapp-runner .
+    cp -r $GLOBAL_CACHE_DIR/$WEBAPP_CACHE_DIR .
 else
-    git clone "${WEBAPP_GIT_URL}" 2>&1 | sed -u 's/^/        /'
+    git clone "${WEBAPP_GIT_URL}" "$WEBAPP_CACHE_DIR" 2>&1 | sed -u 's/^/        /'
 
     if [ -d $GLOBAL_CACHE_DIR ]; then
-        cp -r webapp-runner $GLOBAL_CACHE_DIR
+        cp -r $WEBAPP_CACHE_DIR $GLOBAL_CACHE_DIR
     fi
 fi
 
-cd webapp-runner
+cd $WEBAPP_CACHE_DIR
 
 BUILDCMD="$CACHE_DIR/.maven/bin/mvn -B"
-BUILDCMD="$BUILDCMD -Duser.home=$BUILD_DIR/webapp-runner"
+BUILDCMD="$BUILDCMD -Duser.home=$BUILD_DIR/$WEBAPP_CACHE_DIR"
 BUILDCMD="$BUILDCMD -Dmaven.repo.local=$CACHE_DIR/.m2/repository"
 BUILDCMD="$BUILDCMD -q"
 BUILDCMD="$BUILDCMD $MAVEN_SETTINGS_OPT"
@@ -281,7 +284,7 @@ $BUILDCMD 2>&1 | sed -u 's/^/       /'
 mkdir -p ../target/dependency
 cp "${WEBAPP_TARGET_JAR}" ../target/dependency/webapp-runner.jar
 cd ..
-rm -rf webapp-runner
+rm -rf $WEBAPP_CACHE_DIR
 
 # finalize cache
 if [ "false" == $KEEP_M2_CACHE ]; then

--- a/bin/compile
+++ b/bin/compile
@@ -257,7 +257,7 @@ status "executing $BUILDCMD"
 $BUILDCMD 2>&1 | sed -u 's/^/       /'
 
 mkdir -p ../target/dependency
-cp target/webapp-runner.jar ../target/dependency/webapp-runner.jar
+cp assembly/target/webapp-runner.jar ../target/dependency/webapp-runner.jar
 cd ..
 rm -rf webapp-runner
 


### PR DESCRIPTION
New Java libraries requires Servlet 3.1 support and it exists in embedded Tomcat v8.5. Heroku's webapp-runner uses Tomcat 8.5.51 at the moment.

By this PR the used webapp-runner (i.e. Vincit or heroku version) can be selected by Dokku application's configuration.

~~Note! Usage of `GLOBAL_CACHE_DIR` is not tested and its path should be changed.~~